### PR TITLE
Fix UI bugs and implement chat enhancements

### DIFF
--- a/src/lib/components/chat/CodeBlock.svelte
+++ b/src/lib/components/chat/CodeBlock.svelte
@@ -1,12 +1,27 @@
 <script lang="ts">
 	import { slide } from 'svelte/transition';
+	import { tick } from 'svelte';
 
 	export let code: string = '';
 	export let language: string | undefined = undefined;
 
 	let copied = false;
 	let collapsed = false;
+	let container: HTMLDivElement;
 	let copyTimeout: ReturnType<typeof setTimeout>;
+
+	async function toggleCollapse() {
+		const scrollEl = container?.closest('.scroll-container') as HTMLElement | null;
+		const blockTop = container?.getBoundingClientRect().top ?? 0;
+		collapsed = !collapsed;
+		if (scrollEl) {
+			await tick();
+			requestAnimationFrame(() => {
+				const newBlockTop = container?.getBoundingClientRect().top ?? 0;
+				scrollEl.scrollTop += newBlockTop - blockTop;
+			});
+		}
+	}
 
 	async function copyToClipboard() {
 		try {
@@ -22,12 +37,12 @@
 	}
 </script>
 
-<div class="group relative my-md w-full font-mono text-[14px]">
+<div class="group relative my-md w-full font-mono text-[14px]" bind:this={container}>
 	<div class="code-header">
 		<button
 			type="button"
 			class="code-toggle"
-			on:click={() => (collapsed = !collapsed)}
+			on:click={toggleCollapse}
 			aria-label={collapsed ? 'Expand code block' : 'Collapse code block'}
 		>
 			<svg

--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
   import CodeBlock from './CodeBlock.svelte';
   import { renderMarkdown, renderCodeBlock, initHighlighter } from '$lib/services/markdown';
-  
+
   export let content: string = '';
   export let isDark: boolean = false;
   export let isStreaming: boolean = false;
-  
+
   type MarkdownBlock =
-    | { type: 'html'; html: string }
-    | { type: 'code'; code: string; language?: string; html: string };
+    | { type: 'html'; html: string; isNew?: boolean }
+    | { type: 'code'; code: string; language?: string; html: string; isNew?: boolean };
 
   let blocks: MarkdownBlock[] = [];
+  let prevBlockCount = 0;
 
   function splitMarkdownBlocks(source: string): MarkdownBlock[] {
     const normalizedSource = source.startsWith('[Translation unavailable]')
@@ -79,9 +80,19 @@
   
   async function initialize() {
     await initHighlighter();
-    blocks = splitMarkdownBlocks(content);
+    const newBlocks = splitMarkdownBlocks(content);
+    const oldCount = prevBlockCount;
+    // Mark newly added blocks during streaming
+    blocks = newBlocks.map((b, i) => ({ ...b, isNew: isStreaming && i >= oldCount }));
+    prevBlockCount = newBlocks.length;
+    // Clear isNew flag after animation completes
+    if (isStreaming && newBlocks.length > oldCount) {
+      setTimeout(() => {
+        blocks = blocks.map((b) => ({ ...b, isNew: false }));
+      }, 350);
+    }
   }
-  
+
   $: if (content !== undefined || isDark !== undefined || isStreaming !== undefined) {
     initialize();
   }
@@ -90,16 +101,17 @@
 <div class="markdown-container" class:is-streaming={isStreaming} aria-hidden="false">
   {#each blocks as block}
     {#if block.type === 'html'}
-      <div class="prose max-w-none dark:prose-invert markdown-html">
+      <div class="prose max-w-none dark:prose-invert markdown-html" class:block-fade-in={block.isNew}>
         {@html block.html}
       </div>
     {:else}
-      <CodeBlock code={block.code} language={block.language}>
-        {@html block.html}
-      </CodeBlock>
+      <div class:block-fade-in={block.isNew}>
+        <CodeBlock code={block.code} language={block.language}>
+          {@html block.html}
+        </CodeBlock>
+      </div>
     {/if}
   {/each}
-  {#if isStreaming}<span class="streaming-cursor">▌</span>{/if}
 </div>
 
 <style>
@@ -111,50 +123,25 @@
     margin-bottom: 0;
   }
 
-  .streaming-cursor {
-    display: inline-block;
-    animation: blink 1s step-start infinite;
-    color: currentColor;
-    user-select: none;
+  .block-fade-in {
+    animation: blockFadeIn 300ms var(--ease-out, cubic-bezier(0.4, 0, 0.2, 1)) forwards;
   }
 
-  @keyframes blink {
-    0%, 50% { opacity: 1 }
-    51%, 100% { opacity: 0 }
-  }
-
-  /* Streaming mask effect - creates smooth fade at bottom where new content appears */
-  .is-streaming::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 2.5em;
-    background: linear-gradient(
-      to bottom,
-      transparent 0%,
-      var(--surface-page) 100%
-    );
-    pointer-events: none;
-    opacity: 0.35;
-    animation: streamPulse 1.8s ease-in-out infinite;
-  }
-
-  @keyframes streamPulse {
-    0%, 100% { opacity: 0.25; }
-    50% { opacity: 0.45; }
+  @keyframes blockFadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .streaming-cursor {
+    .block-fade-in {
       animation: none;
       opacity: 1;
-    }
-
-    .is-streaming::after {
-      animation: none;
-      opacity: 0.3;
     }
   }
 </style>

--- a/src/lib/components/chat/MessageArea.svelte
+++ b/src/lib/components/chat/MessageArea.svelte
@@ -5,6 +5,7 @@
 
 	export let messages: ChatMessage[] = [];
 	export let conversationId: string | null = null;
+	export let isThinkingActive: boolean = false;
 
 	const dispatch = createEventDispatcher<{
 		regenerate: { messageId: string };
@@ -55,8 +56,8 @@
 		} else if (isNewMessage) {
 			// New message added: jump directly to the latest content.
 			alignToBottomAfterRender();
-		} else if (shouldAutoScroll) {
-			// Streaming update: instant scroll if already at bottom
+		} else if (shouldAutoScroll && isThinkingActive) {
+			// Only follow during thinking phase; stop once content streaming begins
 			instantScrollToBottom();
 		}
 

--- a/src/lib/components/chat/MessageBubble.svelte
+++ b/src/lib/components/chat/MessageBubble.svelte
@@ -52,7 +52,8 @@
 	// OR the whole message is complete. This keeps the label as "Thinking" between
 	// multi-burst thinking phases (isThinkingStreaming briefly false, but no content yet).
 	$: isDone = !message.isStreaming && !message.isThinkingStreaming;
-	$: showLogoBelow = !isUser && hasThinking;
+	$: isGenerating = Boolean(message.isStreaming || message.isThinkingStreaming);
+	$: showLogoBelow = !isUser && isLast && (hasThinking || isGenerating);
 	$: thinkingIsDone = hasThinking && !message.isThinkingStreaming &&
 		(message.content.trim().length > 0 || isDone);
 
@@ -184,12 +185,12 @@
 					</div>
 				</div>
 			{:else}
-				<div class="whitespace-pre-wrap break-words text-[16px] leading-[1.6]">
+				<div class="whitespace-pre-wrap break-words text-[14px] md:text-[15px] leading-[1.45] md:leading-[1.55]">
 					{message.content}
 				</div>
 			{/if}
 		{:else}
-			<div class="prose-container w-full overflow-hidden text-[16px] leading-[1.6]">
+			<div class="prose-container w-full overflow-hidden text-[14px] md:text-[15px] leading-[1.45] md:leading-[1.55]">
 				<MarkdownRenderer
 					content={message.content}
 					isDark={$isDark}
@@ -312,9 +313,9 @@
 			</button>
 		</div>
 	{/if}
-	{#if showLogoBelow && thinkingIsDone && isLast}
+	{#if showLogoBelow}
 		<div class="logo-signature">
-			<LogoMark animated={false} size={42} />
+			<LogoMark animated={isGenerating} size={42} />
 		</div>
 	{/if}
 </div>
@@ -346,8 +347,8 @@
 	.info-tooltip {
 		position: absolute;
 		bottom: calc(100% + 8px);
-		left: 50%;
-		transform: translateX(-50%) translateY(4px);
+		left: 0;
+		transform: translateY(4px);
 		opacity: 0;
 		visibility: hidden;
 		transition:
@@ -356,13 +357,14 @@
 			visibility var(--duration-standard);
 		z-index: 50;
 		pointer-events: none;
+		max-width: calc(100vw - 2rem);
 	}
 
 	.info-container:hover .info-tooltip,
 	.info-button:focus-visible + .info-tooltip {
 		opacity: 1;
 		visibility: visible;
-		transform: translateX(-50%) translateY(0);
+		transform: translateY(0);
 		pointer-events: auto;
 	}
 

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -21,7 +21,7 @@
 	$: showCharCount = message.length > maxLength * 0.8;
 	$: charCountColor = isOverMaxLength ? 'text-danger' : 'text-text-muted';
 	
-	$: canSend = !isEmpty && !isOverMaxLength && !disabled;
+	$: canSend = !isEmpty && !isOverMaxLength;
 
 	function isMobile(): boolean {
 		return window.matchMedia('(hover: none) and (pointer: coarse)').matches;
@@ -44,8 +44,8 @@
 		if (!textarea) return;
 		const minHeight = 90;
 		textarea.style.height = `${minHeight}px`;
-		const isMobile = window.innerWidth < 768;
-		const maxHeight = isMobile ? 100 : 168;
+		const isMobileDevice = window.innerWidth < 768;
+		const maxHeight = isMobileDevice ? 200 : 168;
 		textarea.style.height = `${Math.max(minHeight, Math.min(textarea.scrollHeight, maxHeight))}px`;
 	}
 
@@ -55,7 +55,7 @@
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'Enter' && !event.shiftKey) {
+		if (event.key === 'Enter' && !event.shiftKey && !isMobile()) {
 			event.preventDefault();
 			send();
 		}
@@ -94,9 +94,8 @@
 			on:input={handleInput}
 			on:keydown={handleKeydown}
 			placeholder="Type a message..."
-			class="composer-textarea min-h-[90px] w-full resize-none overflow-y-auto border-0 bg-transparent px-[16px] py-[8px] text-left text-[16px] leading-[1.35] font-serif text-text-primary placeholder:font-sans placeholder:text-text-muted focus:outline-none focus:ring-0"
+			class="composer-textarea min-h-[90px] w-full resize-none overflow-y-auto border-0 bg-transparent px-[16px] py-[8px] text-left text-[14px] md:text-[15px] leading-[1.35] font-serif text-text-primary placeholder:font-sans placeholder:text-text-muted focus:outline-none focus:ring-0"
 			rows="1"
-			{disabled}
 		></textarea>
 
 		<div class="composer-actions flex items-center justify-between gap-3 pt-[4px] pb-[5px]">
@@ -133,7 +132,7 @@
 						data-testid="send-button"
 						type="button"
 						on:click={send}
-						disabled={!canSend}
+						disabled={!canSend || disabled}
 						aria-label="Send message"
 						class="btn-primary composer-send flex h-full w-full items-center justify-center rounded-[15px] shadow-sm disabled:cursor-not-allowed disabled:border-border disabled:bg-surface-elevated disabled:text-icon-muted animate-in"
 					>

--- a/src/lib/components/chat/ThinkingBlock.svelte
+++ b/src/lib/components/chat/ThinkingBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import type { ThinkingSegment } from '$lib/types';
-	import LogoMark from './LogoMark.svelte';
 
 	export let content: string = '';
 	// True once thinking is definitively over: visible response text has started
@@ -12,6 +12,7 @@
 	export let segments: ThinkingSegment[] = [];
 
 	let expanded = false;
+	let container: HTMLDivElement;
 
 	// "Thought" only once we're sure thinking is over (response text started or done).
 	$: label = thinkingIsDone ? 'Thought' : 'Thinking';
@@ -42,8 +43,17 @@
 		return firstVal() ? `${name}: ${firstVal()}` : name;
 	}
 
-	function toggle() {
+	async function toggle() {
+		const scrollEl = container?.closest('.scroll-container') as HTMLElement | null;
+		const blockTop = container?.getBoundingClientRect().top ?? 0;
 		expanded = !expanded;
+		if (scrollEl) {
+			await tick();
+			requestAnimationFrame(() => {
+				const newBlockTop = container?.getBoundingClientRect().top ?? 0;
+				scrollEl.scrollTop += newBlockTop - blockTop;
+			});
+		}
 	}
 </script>
 
@@ -51,18 +61,13 @@
 	import { slide } from 'svelte/transition';
 </script>
 
-<div class="thinking-block">
+<div class="thinking-block" bind:this={container}>
 	<button
 		type="button"
 		class="thinking-header"
 		on:click={toggle}
 		aria-expanded={expanded}
 	>
-		{#if isActiveThinking}
-			<span class="thinking-logo">
-				<LogoMark animated={true} size={30} />
-			</span>
-		{/if}
 		<span class="thinking-label" class:is-active={isActiveThinking}>{label}</span>
 		<svg
 			class="chevron"
@@ -128,28 +133,27 @@
 <style>
 	.thinking-block {
 		margin-bottom: var(--space-md);
+		width: 100%;
+		max-width: 100%;
+		overflow: hidden;
 	}
 
 	.thinking-header {
-		display: inline-flex;
+		display: flex;
 		align-items: center;
 		gap: var(--space-xs);
 		padding: var(--space-xs) 0;
 		background: transparent;
 		border: none;
 		cursor: pointer;
+		max-width: 100%;
+		width: 100%;
 	}
 
 	.thinking-header:focus-visible {
 		outline: none;
 		box-shadow: 0 0 0 2px var(--focus-ring);
 		border-radius: 2px;
-	}
-
-	.thinking-logo {
-		display: flex;
-		align-items: center;
-		flex-shrink: 0;
 	}
 
 	.thinking-label {

--- a/src/lib/components/search/SearchModal.svelte
+++ b/src/lib/components/search/SearchModal.svelte
@@ -44,9 +44,10 @@
 
 	$: if (browser && isOpen) {
 		previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-		
+
 		tick().then(() => {
-			searchInputRef?.focus();
+			const isMobile = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+			if (!isMobile) searchInputRef?.focus();
 		});
 
 		if ($conversations.length === 0) {

--- a/src/lib/components/sidebar/ConversationList.svelte
+++ b/src/lib/components/sidebar/ConversationList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { fade, slide } from 'svelte/transition';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import {
 		conversations,
 		deleteConversationById,
@@ -65,7 +66,8 @@
 
 	async function handleSelect(event: CustomEvent<{ id: string }>) {
 		const id = event.detail.id;
-		if (id === $currentConversationId) return;
+		const onSettingsPage = $page.url.pathname.startsWith('/settings');
+		if (id === $currentConversationId && !onSettingsPage) return;
 		const previousConversationId = $currentConversationId;
 		openMenuId = null;
 		currentConversationId.set(id);

--- a/src/lib/components/ui/ProfilePictureEditor.svelte
+++ b/src/lib/components/ui/ProfilePictureEditor.svelte
@@ -347,6 +347,7 @@
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby="pic-editor-title"
+		tabindex="-1"
 		class="relative w-full max-w-[520px] rounded-lg border border-border bg-surface-page p-lg shadow-lg"
 		on:click|stopPropagation
 		transition:scale={{ duration: 150, start: 0.95 }}

--- a/src/routes/(app)/chat/[conversationId]/+page.svelte
+++ b/src/routes/(app)/chat/[conversationId]/+page.svelte
@@ -31,6 +31,7 @@
 	let hasPersistedMessages = (data.messages?.length ?? 0) > 0;
 
 	$: hasMessages = $messages.length > 0;
+	$: isThinkingActive = Boolean($messages[$messages.length - 1]?.isThinkingStreaming);
 
 	function maybeSendPendingInitialMessage() {
 		if (typeof window === 'undefined' || isSending || (data.messages?.length ?? 0) > 0) {
@@ -373,7 +374,7 @@
 <div class="chat-page flex h-full min-w-0 flex-col bg-surface-page">
 	<div class="chat-stage relative flex min-h-0 flex-1 overflow-hidden rounded-lg" class:chat-stage-active={hasMessages}>
 		<div class="message-layer min-h-0 flex-1" class:message-layer-active={hasMessages}>
-			<MessageArea messages={$messages} conversationId={data.conversation.id} on:regenerate={handleRegenerate} on:edit={handleEdit} />
+			<MessageArea messages={$messages} conversationId={data.conversation.id} isThinkingActive={isThinkingActive} on:regenerate={handleRegenerate} on:edit={handleEdit} />
 		</div>
 
 		<div class="composer-layer" class:composer-layer-active={hasMessages}>


### PR DESCRIPTION
Bug fixes:
- Tool calls no longer overflow screen width (ThinkingBlock constrained to 100%)
- Info tooltip repositioned to left-align to prevent mobile clipping
- Collapsing code/thinking blocks preserves scroll position (viewport stays anchored)
- Settings page navigation trap fixed: clicking same conversation navigates correctly
- Autofocus no longer triggers keyboard on mobile (textarea and search modal)
- Static logo no longer jumps rows; now appears animated from generation start
- Textarea is no longer disabled during generation (type-ahead while streaming)
- Enter key on mobile inserts line break instead of sending
- Prompt box max height increased on mobile (100px → 200px)

Features:
- Reduced text size in chat and prompt box (16px → 14px/15px with responsive scaling)
- Auto-scroll refined: follows thinking phase only, stops during final output streaming
- Streaming fade-in animation added to new markdown blocks in MarkdownRenderer
- Blinking cursor removed; replaced by animated logo below response during generation
- Logo below response is animated during any streaming, switches to static when done
- Animated logo removed from ThinkingBlock header (consolidated to message bottom)

https://claude.ai/code/session_01QyJ6WmugWnvBp3YZBotwdC