### PR TITLE
Fix tool call overflow, mobile stream abort, and mobile keyboard

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -68,11 +68,16 @@
 		adjustHeight();
 		if (!isMobile()) {
 			textarea.focus();
+		} else {
+			textarea.blur();
 		}
 	}
 
 	function stop() {
 		dispatch('stop');
+		if (isMobile()) {
+			textarea.blur();
+		}
 	}
 
 	onMount(() => {

--- a/src/lib/components/chat/ThinkingBlock.svelte
+++ b/src/lib/components/chat/ThinkingBlock.svelte
@@ -234,6 +234,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		min-width: 0;
 	}
 
 	.check-icon-header {
@@ -282,6 +283,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		min-width: 0;
 	}
 
 	.check-icon {

--- a/src/routes/(app)/chat/[conversationId]/+page.svelte
+++ b/src/routes/(app)/chat/[conversationId]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { writable } from 'svelte/store';
 	import { onMount, onDestroy } from 'svelte';
+	import { invalidateAll } from '$app/navigation';
 	import { currentConversationId } from '$lib/stores/ui';
 	import { selectedModel } from '$lib/stores/settings';
 	import MessageArea from '$lib/components/chat/MessageArea.svelte';
@@ -29,6 +30,9 @@
 	let canRetry = false;
 	let prevConversationId: string | null = null;
 	let hasPersistedMessages = (data.messages?.length ?? 0) > 0;
+	// Set to true when the stream was cancelled by the browser (e.g. mobile backgrounding)
+	// rather than by the user tapping Stop. Triggers a data reload on visibility restore.
+	let streamInterruptedByBackground = false;
 
 	$: hasMessages = $messages.length > 0;
 	$: isThinkingActive = Boolean($messages[$messages.length - 1]?.isThinkingStreaming);
@@ -105,11 +109,21 @@
 		return FRIENDLY_SEND_ERRORS.backend_failure;
 	}
 
+	function handleVisibilityChange() {
+		if (document.visibilityState === 'visible' && streamInterruptedByBackground) {
+			streamInterruptedByBackground = false;
+			invalidateAll();
+		}
+	}
+
 	onMount(() => {
 		currentConversationId.set(data.conversation.id);
+		document.addEventListener('visibilitychange', handleVisibilityChange);
 	});
 
 	onDestroy(() => {
+		document.removeEventListener('visibilitychange', handleVisibilityChange);
+
 		if (activeStream) {
 			activeStream.abort();
 			activeStream = null;
@@ -283,9 +297,19 @@
 				},
 				onError(err) {
 					messages.update((msgs) => msgs.filter((m) => m.id !== placeholderId));
-					sendError = toFriendlySendError(err);
-					isSending = false;
 					activeStream = null;
+					isSending = false;
+
+					// Detect browser-initiated abort (mobile backgrounding / connection drop).
+					// The server continues generating and persists the result; reload on return.
+					const isBrowserAbort =
+						err.name === 'AbortError' && document.visibilityState === 'hidden';
+					if (isBrowserAbort) {
+						streamInterruptedByBackground = true;
+						return;
+					}
+
+					sendError = toFriendlySendError(err);
 					canRetry = true;
 				}
 			},

--- a/src/routes/api/chat/stream/+server.ts
+++ b/src/routes/api/chat/stream/+server.ts
@@ -609,7 +609,8 @@ export const POST: RequestHandler = async (event) => {
 				if (closed) return;
 				closed = true;
 				downstreamAbortSignal.removeEventListener('abort', closeStream);
-				upstreamAbortController.abort();
+				// Do NOT abort upstream on client disconnect — let generation complete and persist to DB.
+				// The client reloads persisted messages on visibility restore (mobile background fix).
 				try {
 					controller.close();
 				} catch {
@@ -634,7 +635,8 @@ export const POST: RequestHandler = async (event) => {
 					return true;
 				} catch {
 					closed = true;
-					upstreamAbortController.abort();
+					// Do NOT abort upstream on client disconnect — let generation complete and persist to DB.
+				// The client reloads persisted messages on visibility restore (mobile background fix).
 					return false;
 				}
 			};


### PR DESCRIPTION
Tool call overflow: Add min-width:0 to .tool-label-text and .tool-item-label so flex items can shrink below content width, allowing text-overflow:ellipsis to truncate long tool call strings.

Mobile stream abort: Decouple client disconnect from upstream abort on the server — when mobile browser backgrounds the page and drops the HTTP connection, the AI generation now continues to completion and persists to DB. On the client, browser-initiated AbortErrors (page hidden) silently schedule an invalidateAll() reload on visibility restore instead of showing an error banner.

Mobile keyboard: Explicitly blur the textarea after send() and stop() on mobile so the keyboard closes when the user submits or stops.

https://claude.ai/code/session_01QyJ6WmugWnvBp3YZBotwdC