### PR TITLE
Make block fade-in animation more pronounced

### DIFF
--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -89,7 +89,7 @@
     if (isStreaming && newBlocks.length > oldCount) {
       setTimeout(() => {
         blocks = blocks.map((b) => ({ ...b, isNew: false }));
-      }, 350);
+      }, 500);
     }
   }
 
@@ -124,17 +124,17 @@
   }
 
   .block-fade-in {
-    animation: blockFadeIn 300ms var(--ease-out, cubic-bezier(0.4, 0, 0.2, 1)) forwards;
+    animation: blockFadeIn 450ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
   }
 
   @keyframes blockFadeIn {
     from {
       opacity: 0;
-      transform: translateY(3px);
+      transform: translateY(14px) scale(0.97);
     }
     to {
       opacity: 1;
-      transform: translateY(0);
+      transform: translateY(0) scale(1);
     }
   }
 


### PR DESCRIPTION
Increase translateY from 3px to 14px, add scale(0.97->1), extend duration to 450ms with a spring easing. Also extend the isNew flag lifetime to 500ms to match. Fires on each new markdown block appearing during streaming (new paragraphs, code fences).

https://claude.ai/code/session_01QyJ6WmugWnvBp3YZBotwdC