### PR TITLE
Fix fade-in animation not playing and redirect on chat load errors

### DIFF
--- a/src/lib/components/chat/MarkdownRenderer.svelte
+++ b/src/lib/components/chat/MarkdownRenderer.svelte
@@ -82,8 +82,11 @@
     await initHighlighter();
     const newBlocks = splitMarkdownBlocks(content);
     const oldCount = prevBlockCount;
-    // Mark newly added blocks during streaming
-    blocks = newBlocks.map((b, i) => ({ ...b, isNew: isStreaming && i >= oldCount }));
+    // Mark newly added blocks during streaming, preserve isNew on existing animating blocks
+    blocks = newBlocks.map((b, i) => ({
+      ...b,
+      isNew: (isStreaming && i >= oldCount) || (blocks[i]?.isNew === true)
+    }));
     prevBlockCount = newBlocks.length;
     // Clear isNew flag after animation completes
     if (isStreaming && newBlocks.length > oldCount) {

--- a/src/routes/(app)/chat/[conversationId]/+page.ts
+++ b/src/routes/(app)/chat/[conversationId]/+page.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 import type { ConversationDetail } from '$lib/types';
 
@@ -7,12 +7,12 @@ export const load: PageLoad = async ({ params, fetch }) => {
 
 	const res = await fetch(`/api/conversations/${conversationId}`);
 
-	if (res.status === 404) {
-		throw error(404, 'Conversation not found');
+	if (res.status === 404 || res.status === 500) {
+		throw redirect(302, '/');
 	}
 
 	if (!res.ok) {
-		throw error(res.status, 'Failed to load conversation');
+		throw redirect(302, '/');
 	}
 
 	const detail: ConversationDetail = await res.json();


### PR DESCRIPTION
Animation bug: each streaming token re-ran initialize(), overwriting isNew back to false before the animation could play. Now preserve isNew:true on existing blocks until the timeout clears it.

Redirect: chat page now redirects to / on 404 or 500 (e.g. "document not found") instead of rendering an error page.

https://claude.ai/code/session_01QyJ6WmugWnvBp3YZBotwdC