### PR TITLE
Support both conversation_id and conversationId in Langflow file-production node

### DIFF
--- a/langflow_nodes/file_production_tool.py
+++ b/langflow_nodes/file_production_tool.py
@@ -156,9 +156,14 @@ class FileProductionToolComponent(Component):
     def _get_conversation_id(self) -> str | None:
         """Get the conversation ID from the Langflow session."""
         try:
-            explicit = str(getattr(self, "conversation_id", "") or "").strip()
-            if explicit:
-                return explicit
+            explicit_snake = str(getattr(self, "conversation_id", "") or "").strip()
+            if explicit_snake:
+                return explicit_snake
+
+            explicit_camel = str(getattr(self, "conversationId", "") or "").strip()
+            if explicit_camel:
+                return explicit_camel
+
             if hasattr(self, "graph") and self.graph is not None:
                 return getattr(self.graph, "session_id", None)
         except Exception as exc:

--- a/src/lib/server/services/file-production/langflow-node.test.ts
+++ b/src/lib/server/services/file-production/langflow-node.test.ts
@@ -35,5 +35,7 @@ describe('Langflow File Production tool node', () => {
 		expect(source).not.toContain('/api/chat/files/generate');
 		expect(source).not.toContain('/api/chat/files/export');
 		expect(source).toContain('"requestedOutputs": requested_outputs');
+		expect(source).toContain('getattr(self, "conversation_id", "")');
+		expect(source).toContain('getattr(self, "conversationId", "")');
 	});
 });


### PR DESCRIPTION
### Motivation
- Langflow integrations sometimes provide conversation identifiers in camelCase, causing the node to silently fall back to `graph.session_id` and trigger intermittent 404s during `produce_file` calls.
- Make the node more robust to attribute naming differences to reduce integration fragility.

### Description
- Update `langflow_nodes/file_production_tool.py` so `_get_conversation_id()` checks `conversation_id` first, then `conversationId`, and only then falls back to `graph.session_id`.
- Add a string-level unit assertion in `src/lib/server/services/file-production/langflow-node.test.ts` that the node source includes both `getattr(self, "conversation_id", "")` and `getattr(self, "conversationId", "")` lookups.
- Preserve existing payload/service-assertion behavior and tool contract while improving attribute lookup order.

### Testing
- Ran the focused Vitest suite: `npm test -- src/lib/server/services/file-production/langflow-node.test.ts`, and the test file passed. 
- The updated test asserts the presence of both attribute lookups and the existing contract assertions, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87d6b1d208323b046b56a8b0d8797)