### PR TITLE
fix: add Xiaomi MiMo OpenAI-compatible request handling

### DIFF
--- a/src/lib/server/services/normal-chat-model/provider-compatibility.test.ts
+++ b/src/lib/server/services/normal-chat-model/provider-compatibility.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildNormalChatModelRunCompatibilityProviderOptions,
+	transformNormalChatModelRunRequestBody,
+	type NormalChatModelRunCompatibilityProvider,
+} from "./provider-compatibility";
+
+const mimoProvider: NormalChatModelRunCompatibilityProvider = {
+	name: "xiaomi_mimo",
+	displayName: "Xiaomi MiMo",
+	baseUrl: "https://api.xiaomimimo.com/v1",
+	modelName: "mimo-v2.5-pro",
+};
+
+describe("Xiaomi MiMo provider compatibility", () => {
+	it("uses max_completion_tokens instead of max_tokens", () => {
+		const transformed = transformNormalChatModelRunRequestBody(
+			{
+				model: "mimo-v2.5-pro",
+				messages: [{ role: "user", content: "Hello" }],
+				max_tokens: 4096,
+			},
+			mimoProvider,
+		);
+
+		expect(transformed).toMatchObject({
+			model: "mimo-v2.5-pro",
+			max_completion_tokens: 4096,
+		});
+		expect(transformed).not.toHaveProperty("max_tokens");
+	});
+
+	it("detects MiMo from model name even when provider metadata is generic", () => {
+		const transformed = transformNormalChatModelRunRequestBody(
+			{
+				model: "mimo-v2.5-pro",
+				messages: [{ role: "user", content: "Hello" }],
+				max_tokens: 1024,
+			},
+			{
+				name: "model1",
+				displayName: "Primary Model",
+				baseUrl: "https://gateway.example.test/v1",
+				modelName: "mimo-v2.5-pro",
+			},
+		);
+
+		expect(transformed).toMatchObject({ max_completion_tokens: 1024 });
+		expect(transformed).not.toHaveProperty("max_tokens");
+	});
+
+	it("leaves MiMo reasoning controls under model/UI configuration", () => {
+		const options = buildNormalChatModelRunCompatibilityProviderOptions(
+			{
+				...mimoProvider,
+				reasoningEffort: "high",
+				thinkingType: "enabled",
+			},
+			"on",
+		);
+
+		expect(options).toEqual({
+			reasoningEffort: "high",
+			thinking: { type: "enabled" },
+		});
+	});
+
+	it("does not rewrite max_tokens for otherwise generic providers", () => {
+		const transformed = transformNormalChatModelRunRequestBody(
+			{
+				model: "generic-chat-model",
+				messages: [{ role: "user", content: "Hello" }],
+				max_tokens: 512,
+			},
+			{
+				name: "generic",
+				displayName: "Generic",
+				baseUrl: "https://gateway.example.test/v1",
+				modelName: "generic-chat-model",
+			},
+		);
+
+		expect(transformed).toMatchObject({ max_tokens: 512 });
+		expect(transformed).not.toHaveProperty("max_completion_tokens");
+	});
+});

--- a/src/lib/server/services/normal-chat-model/provider-compatibility.ts
+++ b/src/lib/server/services/normal-chat-model/provider-compatibility.ts
@@ -57,7 +57,7 @@ export function transformNormalChatModelRunRequestBody(
 	}
 
 	const family = identifyProviderFamily(provider);
-	if (family === "openai" && transformed.max_tokens !== undefined) {
+	if (usesMaxCompletionTokens(family) && transformed.max_tokens !== undefined) {
 		transformed.max_completion_tokens = transformed.max_tokens;
 		delete transformed.max_tokens;
 	}
@@ -74,7 +74,13 @@ export function transformNormalChatModelRunRequestBody(
 	return transformed;
 }
 
-type ProviderFamily = "openai" | "deepseek" | "kimi" | "qwen" | "generic";
+type ProviderFamily =
+	| "openai"
+	| "deepseek"
+	| "kimi"
+	| "qwen"
+	| "mimo"
+	| "generic";
 
 function identifyProviderFamily(
 	provider: NormalChatModelRunCompatibilityProvider,
@@ -104,7 +110,14 @@ function identifyProviderFamily(
 	if (/\bqwen\b|qwen-|dashscope|qwencloud|aliyun|alibaba/.test(haystack)) {
 		return "qwen";
 	}
+	if (/\bmimo\b|mimo-|xiaomimimo|api\.xiaomimimo\./.test(haystack)) {
+		return "mimo";
+	}
 	return "generic";
+}
+
+function usesMaxCompletionTokens(family: ProviderFamily): boolean {
+	return family === "openai" || family === "mimo";
 }
 
 function resolveThinkingType(

--- a/tests/fixtures/ai/openai-compatible-scenarios.ts
+++ b/tests/fixtures/ai/openai-compatible-scenarios.ts
@@ -23,4 +23,5 @@ export const AI_SMOKE_SCENARIOS = {
 	timeoutAbort: "timeout-abort",
 	rateLimit: "rate-limit",
 	serverError: "server-error",
+	mimoRejectsMaxTokens: "mimo-rejects-max-tokens",
 } as const;

--- a/tests/integration/xiaomi-mimo-openai-compatible-provider.test.ts
+++ b/tests/integration/xiaomi-mimo-openai-compatible-provider.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { runPlainNormalChatModelRun } from "$lib/server/services/normal-chat-model";
+import {
+	AI_SMOKE_API_KEY,
+	AI_SMOKE_MODEL_ID,
+	AI_SMOKE_PLAIN_TEXT,
+	AI_SMOKE_SCENARIOS,
+} from "../fixtures/ai/openai-compatible-scenarios";
+import { createOpenAICompatibleProviderHarness } from "../mocks/ai-provider/openai-compatible-provider";
+
+const provider = createOpenAICompatibleProviderHarness();
+
+describe("Xiaomi MiMo OpenAI-compatible provider smoke", () => {
+	afterAll(async () => {
+		await provider.stop();
+	});
+
+	beforeEach(async () => {
+		await provider.start();
+		await provider.reset();
+	});
+
+	it("sends MiMo max output as max_completion_tokens", async () => {
+		const result = await runPlainNormalChatModelRun({
+			provider: {
+				id: "xiaomi-mimo-provider",
+				name: "xiaomi_mimo",
+				displayName: "Xiaomi MiMo",
+				baseUrl: provider.baseURL,
+				modelName: "mimo-v2.5-pro",
+				apiKey: AI_SMOKE_API_KEY,
+				maxOutputTokens: 321,
+			},
+			headers: {
+				"x-ai-smoke-scenario": AI_SMOKE_SCENARIOS.mimoRejectsMaxTokens,
+			},
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "text", text: "Say hello deterministically." }],
+				},
+			],
+		});
+
+		expect(result.text).toBe(AI_SMOKE_PLAIN_TEXT);
+		expect(result.model.requestedModelName).toBe("mimo-v2.5-pro");
+		expect(provider.requests()).toMatchObject([
+			{
+				method: "POST",
+				path: "/v1/chat/completions",
+				scenario: AI_SMOKE_SCENARIOS.mimoRejectsMaxTokens,
+				body: {
+					model: "mimo-v2.5-pro",
+					max_completion_tokens: 321,
+				},
+			},
+		]);
+		expect(provider.requests()[0]?.body).not.toHaveProperty("max_tokens");
+	});
+});

--- a/tests/integration/xiaomi-mimo-openai-compatible-provider.test.ts
+++ b/tests/integration/xiaomi-mimo-openai-compatible-provider.test.ts
@@ -2,7 +2,6 @@ import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { runPlainNormalChatModelRun } from "$lib/server/services/normal-chat-model";
 import {
 	AI_SMOKE_API_KEY,
-	AI_SMOKE_MODEL_ID,
 	AI_SMOKE_PLAIN_TEXT,
 	AI_SMOKE_SCENARIOS,
 } from "../fixtures/ai/openai-compatible-scenarios";


### PR DESCRIPTION
## Summary

- Adds Xiaomi MiMo provider-family detection for OpenAI-compatible normal chat model runs.
- Rewrites `max_tokens` to `max_completion_tokens` for MiMo, matching the Xiaomi MiMo OpenAI-compatible API shape.
- Keeps MiMo reasoning controls governed by existing model/UI configuration; this PR does **not** disable reasoning by default.
- Adds focused regression coverage for MiMo token normalization and reasoning option pass-through.
- Adds a mock-provider smoke test that uses the existing OpenAI-compatible harness and verifies the actual outgoing MiMo request body.

## Test status

I could not run the repo test suite in this sandbox because outbound access to `github.com` is unavailable for cloning/installing dependencies here.

Suggested local checks:

```bash
npm run test -- src/lib/server/services/normal-chat-model/provider-compatibility.test.ts tests/integration/xiaomi-mimo-openai-compatible-provider.test.ts
npm run check
```

## Follow-up

Reasoning-content replay for MiMo thinking + tool loops is intentionally not addressed here. That should be a separate design/implementation discussion because it affects message persistence and provider-specific assistant metadata replay.