### PR TITLE
feat: add turn language state helper

### DIFF
--- a/src/lib/server/services/turn-language-state.test.ts
+++ b/src/lib/server/services/turn-language-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildTurnLanguageState,
+	detectShortHungarianFollowUp,
+	normalizeHungarianRetrievalTerms,
+	resolveExplicitResponseLanguage
+} from './turn-language-state';
+
+describe('detectShortHungarianFollowUp', () => {
+	it('recognizes short multi-token Hungarian follow-ups', () => {
+		expect(detectShortHungarianFollowUp('mi ez?')).toBe(true);
+		expect(detectShortHungarianFollowUp('ez mi?')).toBe(true);
+		expect(detectShortHungarianFollowUp('nem kell')).toBe(true);
+	});
+
+	it('does not treat English short inputs as Hungarian', () => {
+		expect(detectShortHungarianFollowUp('no')).toBe(false);
+		expect(detectShortHungarianFollowUp('ok')).toBe(false);
+	});
+});
+
+describe('resolveExplicitResponseLanguage', () => {
+	it('detects explicit English output requests from Hungarian instructions', () => {
+		expect(resolveExplicitResponseLanguage('Írj egy angol emailt erről.')).toBe('en');
+		expect(resolveExplicitResponseLanguage('Answer in English: mit jelent ez?')).toBe('en');
+	});
+
+	it('detects explicit Hungarian output requests without matching topic mentions', () => {
+		expect(resolveExplicitResponseLanguage('Write this in Hungarian.')).toBe('hu');
+		expect(resolveExplicitResponseLanguage('Kérlek válaszolj magyarul.')).toBe('hu');
+		expect(resolveExplicitResponseLanguage('Write a report about the Hungarian parliament.')).toBeNull();
+	});
+});
+
+describe('normalizeHungarianRetrievalTerms', () => {
+	it('keeps accented terms and adds suffix-stripped variants', () => {
+		const terms = normalizeHungarianRetrievalTerms(
+			'Keress rá a korábbi beszélgetéseimben a kerékpár biztosításra.'
+		);
+		expect(terms).toEqual(expect.arrayContaining(['kerékpár', 'biztosításra', 'biztosítás']));
+	});
+});
+
+describe('buildTurnLanguageState', () => {
+	it('separates Hungarian user language from explicit English response language', () => {
+		const state = buildTurnLanguageState('Írj egy angol emailt erről a dokumentumról.');
+		expect(state.userLanguage).toBe('hu');
+		expect(state.explicitResponseLanguage).toBe('en');
+		expect(state.responseLanguage).toBe('en');
+		expect(state.retrievalQueries.normalized).toContain('dokumentum');
+	});
+
+	it('keeps Hungarian response language when no output override is present', () => {
+		const state = buildTurnLanguageState('Mit mond ez a fájl a felmondási időről?');
+		expect(state.userLanguage).toBe('hu');
+		expect(state.explicitResponseLanguage).toBeNull();
+		expect(state.responseLanguage).toBe('hu');
+		expect(state.retrievalQueries.normalized).toContain('felmondási');
+		expect(state.retrievalQueries.normalized).toContain('idő');
+	});
+
+	it('uses the short Hungarian override for short follow-ups', () => {
+		const state = buildTurnLanguageState('mi ez?');
+		expect(state.userLanguage).toBe('hu');
+		expect(state.responseLanguage).toBe('hu');
+		expect(state.detectionReasons).toContain('short_hungarian_follow_up');
+	});
+});

--- a/src/lib/server/services/turn-language-state.ts
+++ b/src/lib/server/services/turn-language-state.ts
@@ -1,0 +1,148 @@
+import { detectLanguage, type SupportedLanguage } from './language';
+
+export type LanguageDetectionConfidence = 'high' | 'medium' | 'low';
+
+export type TurnLanguageState = {
+	userLanguage: SupportedLanguage;
+	responseLanguage: SupportedLanguage;
+	explicitResponseLanguage: SupportedLanguage | null;
+	confidence: LanguageDetectionConfidence;
+	detectionReasons: string[];
+	retrievalQueries: {
+		original: string;
+		normalized?: string;
+	};
+};
+
+const HUNGARIAN_QUERY_STOPWORDS = new Set([
+	'a',
+	'az',
+	'ez',
+	'ezt',
+	'egy',
+	'és',
+	'vagy',
+	'hogy',
+	'de',
+	'ha',
+	'akkor',
+	'mert',
+	'nem',
+	'van',
+	'volt',
+	'lesz',
+	'mi',
+	'mit',
+	'milyen',
+	'hogyan',
+	'hol',
+	'mikor',
+	'melyik',
+	'keress',
+	'keres',
+	'rá',
+	'ra',
+	'korábbi',
+	'korabbi',
+	'beszélgetéseimben',
+	'beszelgeteseimben',
+	'kérlek',
+	'kerlek'
+]);
+
+const HUNGARIAN_RETRIEVAL_SUFFIXES = [
+	'nak',
+	'nek',
+	'ban',
+	'ben',
+	'val',
+	'vel',
+	'ból',
+	'ből',
+	'rol',
+	'ról',
+	'ről',
+	'tól',
+	'től',
+	'hoz',
+	'hez',
+	'höz',
+	'ért',
+	'ként',
+	'ra',
+	're',
+	'nál',
+	'nél',
+	'ul',
+	'ül'
+];
+
+const HUNGARIAN_MARKERS = /[áéíóöőúüű]/i;
+const HUNGARIAN_SHORT_SIGNAL_RE = /\b(mi|ez|nem|jó|jo|kell|igen|szia|köszi|koszi|oké|oke)\b/iu;
+const EXPLICIT_ENGLISH_RESPONSE_RE =
+	/(\b(in|as)\s+english\b|\benglish\s+(email|message|reply|answer|version|translation|text)\b|\bangolul\b|\bangol\s+(emailt|levelet|választ|valaszt|szöveget|szoveget|verziót|verziot)\b)/iu;
+const EXPLICIT_HUNGARIAN_RESPONSE_RE =
+	/(\b(in|as)\s+hungarian\b|\bhungarian\s+(language|version|translation|text)\b|\bmagyarul\b|\bmagyar\s+(nyelven|emailt|levelet|választ|valaszt|szöveget|szoveget|verziót|verziot)\b)/iu;
+
+function tokenizeWords(text: string): string[] {
+	return (text.toLowerCase().match(/[\p{L}]+/gu) ?? []).filter(Boolean);
+}
+
+function stripHungarianRetrievalSuffix(token: string): string {
+	for (const suffix of HUNGARIAN_RETRIEVAL_SUFFIXES) {
+		if (token.length > suffix.length + 4 && token.endsWith(suffix)) {
+			return token.slice(0, -suffix.length);
+		}
+	}
+	return token;
+}
+
+export function detectShortHungarianFollowUp(text: string): boolean {
+	const trimmed = text.trim();
+	if (!trimmed || trimmed.length >= 10) return false;
+	return HUNGARIAN_SHORT_SIGNAL_RE.test(trimmed) || HUNGARIAN_MARKERS.test(trimmed);
+}
+
+export function normalizeHungarianRetrievalTerms(text: string): string[] {
+	const terms = new Set<string>();
+	for (const token of tokenizeWords(text)) {
+		if (token.length < 2 || HUNGARIAN_QUERY_STOPWORDS.has(token)) continue;
+		terms.add(token);
+		const stripped = stripHungarianRetrievalSuffix(token);
+		if (stripped !== token && stripped.length >= 3 && !HUNGARIAN_QUERY_STOPWORDS.has(stripped)) {
+			terms.add(stripped);
+		}
+	}
+	return Array.from(terms);
+}
+
+export function resolveExplicitResponseLanguage(text: string): SupportedLanguage | null {
+	if (EXPLICIT_ENGLISH_RESPONSE_RE.test(text)) return 'en';
+	if (EXPLICIT_HUNGARIAN_RESPONSE_RE.test(text)) return 'hu';
+	return null;
+}
+
+function resolveUserLanguage(input: string): SupportedLanguage {
+	return detectShortHungarianFollowUp(input) ? 'hu' : detectLanguage(input);
+}
+
+export function buildTurnLanguageState(input: string): TurnLanguageState {
+	const userLanguage = resolveUserLanguage(input);
+	const explicitResponseLanguage = resolveExplicitResponseLanguage(input);
+	const responseLanguage = explicitResponseLanguage ?? userLanguage;
+	const retrievalTerms = userLanguage === 'hu' ? normalizeHungarianRetrievalTerms(input) : [];
+
+	return {
+		userLanguage,
+		responseLanguage,
+		explicitResponseLanguage,
+		confidence: detectShortHungarianFollowUp(input) ? 'high' : 'medium',
+		detectionReasons: detectShortHungarianFollowUp(input)
+			? ['short_hungarian_follow_up']
+			: ['detected_by_language_service'],
+		retrievalQueries: {
+			original: input,
+			...(retrievalTerms.length > 0 ? { normalized: retrievalTerms.join(' ') } : {})
+		}
+	};
+}


### PR DESCRIPTION
## Summary

Adds a focused PR 2 foundation for stable multilingual turn handling:

- introduces `buildTurnLanguageState()` to keep user language, response language, explicit output-language override, confidence, reasons, and retrieval query variants together in one deterministic object;
- adds `detectShortHungarianFollowUp()` so short Hungarian follow-ups like `mi ez?`, `ez mi?`, and `nem kell` can be handled as Hungarian by callers using the helper even before the legacy detector is fully refactored;
- adds `resolveExplicitResponseLanguage()` to separate the user instruction language from requested output language, e.g. `Írj egy angol emailt...` => user language `hu`, response language `en`;
- adds `normalizeHungarianRetrievalTerms()` to keep accented Hungarian terms and add simple suffix-stripped retrieval variants, e.g. `biztosításra` also contributes `biztosítás`;
- adds focused tests for the helper behavior.

## Practical effect

This gives the normal-chat pipeline a central, test-covered language-state API to adopt in follow-up wiring. It avoids mixing up:

- the language the user is speaking;
- the language they want the answer/artifact in;
- the normalized terms that should be used for retrieval.

## Scope note

This PR intentionally does not rewrite the full normal-chat orchestration in one pass. It adds the stable helper and regression tests first so subsequent wiring can replace repeated ad hoc `detectLanguage()` calls safely.

## Tests

Not run in this sandbox. The sandbox still cannot clone from GitHub or install/run the repo test suite. Recommended local checks:

```bash
npm run test -- src/lib/server/services/turn-language-state.test.ts src/lib/server/services/language.test.ts
npm run check
```

## Notes

No provider/model adapter behavior changed. No Honcho API behavior changed.